### PR TITLE
Fix Json pbp Period info parsing

### DIFF
--- a/hockey_scraper/nhl/pbp/json_pbp.py
+++ b/hockey_scraper/nhl/pbp/json_pbp.py
@@ -89,7 +89,7 @@ def parse_event(event):
     play = dict()
 
     play['event_id'] = event['eventId']
-    play['period'] = event['period']
+    play['period'] = event['periodDescriptor']['number']
     play['event'] = str(change_event_name(event['typeDescKey'].upper()))
     play['seconds_elapsed'] = shared.convert_to_seconds(event['timeInPeriod'])
     


### PR DESCRIPTION
Looks like the json format has been updated sometime recently now looks like this:

"periodDescriptor": {
        "number": 5,
        "periodType": "SO"
    },


(I used the Red Wing's recent heartbreak as a reference point [here](https://api-web.nhle.com/v1/gamecenter/2023021298/play-by-play))

I did a quick validation with scrape_games pointing to that specific game and I get a complete pbp file with xy coordinates resolved.